### PR TITLE
图片宽限制

### DIFF
--- a/src/Parsedown.php
+++ b/src/Parsedown.php
@@ -1148,6 +1148,7 @@ class Parsedown
                 'attributes' => array(
                     'src' => $Link['element']['attributes']['href'],
                     'alt' => $Link['element']['text'],
+                    'style' => 'max-width:100%',
                 ),
             ),
         );


### PR DESCRIPTION
在解析markdown时，限制图片的最大宽度不能超过容器的最大宽度，最低程度保证页面不乱
